### PR TITLE
Fix layer filtering

### DIFF
--- a/src/napari_stitcher/_stitcher_widget.py
+++ b/src/napari_stitcher/_stitcher_widget.py
@@ -454,7 +454,7 @@ class StitcherQWidget(QWidget):
             )
             return
 
-        self.load_layers(self.viewer.layers)
+        self.load_layers(self.compatible_layers)
 
 
     def load_layers_sel(self):
@@ -466,7 +466,8 @@ class StitcherQWidget(QWidget):
             )
             return
 
-        self.load_layers([l for l in self.viewer.layers.selection])
+        selected_layers = [l for l in self.compatible_layers if l in self.viewer.layers.selection]
+        self.load_layers(selected_layers)
 
 
     def load_layers(self, layers):
@@ -593,6 +594,13 @@ class StitcherQWidget(QWidget):
         for l in self.viewer.layers:
             if l.name in self.layers_selection.choices:
                 l.events.disconnect(self.watch_layer_changes)
+
+    @property
+    def compatible_layers(self):
+        """
+        Check if layers are compatible with the current widget.
+        """
+        return [l for l in self.viewer.layers if isinstance(l, (Image, Labels))]
 
 
 if __name__ == "__main__":

--- a/src/napari_stitcher/_stitcher_widget.py
+++ b/src/napari_stitcher/_stitcher_widget.py
@@ -600,12 +600,6 @@ class StitcherQWidget(QWidget):
         for l in self.viewer.layers:
             if l.name in self.layers_selection.choices:
                 l.events.disconnect(self.watch_layer_changes)
-    
-    def _get_compatible_layers(self, only_selected=False):
-        if only_selected:
-            return [l for l in self.viewer.layers.selection if isinstance(l, (Image, Labels))]
-        else:
-            return [l for l in self.viewer.layers if isinstance(l, (Image, Labels))]
 
 
 if __name__ == "__main__":

--- a/src/napari_stitcher/_stitcher_widget.py
+++ b/src/napari_stitcher/_stitcher_widget.py
@@ -453,16 +453,8 @@ class StitcherQWidget(QWidget):
                 'No images in the layer list.'
             )
             return
-        
-        layers = self._get_compatible_layers(only_selected=False)
 
-        if len(layers) == 0:
-            notifications.notification_manager.receive_info(
-                'No compatible layers found.'
-            )
-            return
-
-        self.load_layers(layers)
+        self.load_layers(self.viewer.layers)
 
 
     def load_layers_sel(self):
@@ -473,15 +465,8 @@ class StitcherQWidget(QWidget):
                     %('control' if ('command' in sys.platform) else 'shift')
             )
             return
-        
-        layers = self._get_compatible_layers(only_selected=True)
-        if len(layers) == 0:
-            notifications.notification_manager.receive_info(
-                'No compatible layers selected.'
-            )
-            return
 
-        self.load_layers(layers)
+        self.load_layers(self.viewer.layers.selection)
 
 
     def load_layers(self, layers):
@@ -489,9 +474,16 @@ class StitcherQWidget(QWidget):
         self.reset()
         self.viewer.layers.unlink_layers()
 
-        self.layers_selection.choices = sorted([l.name for l in layers])
+        layers = [l for l in layers if isinstance(l, (Image, Labels))]
 
-        self.input_layers = [l for l in layers if isinstance(l, (Image, Labels))]
+        if len(layers) == 0:
+            notifications.notification_manager.receive_info(
+                'No compatible layers selected or available.'
+            )
+            return
+
+        self.input_layers = layers
+        self.layers_selection.choices = sorted([l.name for l in layers])
 
         # load in layers as msims
         for l in self.input_layers:

--- a/src/napari_stitcher/_stitcher_widget.py
+++ b/src/napari_stitcher/_stitcher_widget.py
@@ -24,6 +24,7 @@ from multiview_stitcher import (
     spatial_image_utils,
     msi_utils,
     )
+from napari.layers import Image, Labels
 
 from napari_stitcher import _reader, viewer_utils, _utils
 
@@ -124,7 +125,7 @@ class StitcherQWidget(QWidget):
         # Initialize tab screen 
         self.reg_config_widgets_tabs = QTabWidget() 
         self.reg_config_widgets_tabs.resize(300, 200) 
-  
+   
         # Add tabs 
         self.reg_config_widgets_tabs.addTab(
             widgets.VBox(widgets=self.reg_config_widgets_basic).native, "Basic") 
@@ -475,10 +476,10 @@ class StitcherQWidget(QWidget):
 
         self.layers_selection.choices = sorted([l.name for l in layers])
 
-        self.input_layers = [l for l in layers]
+        self.input_layers = [l for l in layers if isinstance(l, (Image, Labels))]
 
         # load in layers as msims
-        for l in layers:
+        for l in self.input_layers:
             msim = viewer_utils.image_layer_to_msim(l, self.viewer)
             
             if 'c' in msim['scale0/image'].dims:
@@ -505,7 +506,7 @@ class StitcherQWidget(QWidget):
             self.link_view_layers(layers)
 
         # if loaded layer changes, update msim
-        for l in layers:
+        for l in self.input_layers:
             l.events.connect(self.watch_layer_changes)
 
         self.load_metadata()
@@ -513,7 +514,6 @@ class StitcherQWidget(QWidget):
 
     def watch_layer_changes(self, event):
         """
-
         Watch changes in layers and warn user or update msims accordingly.
         I.e. changes in transformations.
         """
@@ -606,3 +606,4 @@ if __name__ == "__main__":
     
     wdg = StitcherQWidget(viewer)
     viewer.window.add_dock_widget(wdg)
+

--- a/src/napari_stitcher/_stitcher_widget.py
+++ b/src/napari_stitcher/_stitcher_widget.py
@@ -453,8 +453,16 @@ class StitcherQWidget(QWidget):
                 'No images in the layer list.'
             )
             return
+        
+        layers = self._get_compatible_layers(only_selected=False)
 
-        self.load_layers(self._get_compatible_layers(only_selected=False))
+        if len(layers) == 0:
+            notifications.notification_manager.receive_info(
+                'No compatible layers found.'
+            )
+            return
+
+        self.load_layers(layers)
 
 
     def load_layers_sel(self):
@@ -465,8 +473,15 @@ class StitcherQWidget(QWidget):
                     %('control' if ('command' in sys.platform) else 'shift')
             )
             return
+        
+        layers = self._get_compatible_layers(only_selected=True)
+        if len(layers) == 0:
+            notifications.notification_manager.receive_info(
+                'No compatible layers selected.'
+            )
+            return
 
-        self.load_layers(self._get_compatible_layers(only_selected=True))
+        self.load_layers(layers)
 
 
     def load_layers(self, layers):

--- a/src/napari_stitcher/_stitcher_widget.py
+++ b/src/napari_stitcher/_stitcher_widget.py
@@ -454,7 +454,7 @@ class StitcherQWidget(QWidget):
             )
             return
 
-        self.load_layers(self.compatible_layers)
+        self.load_layers(self._get_compatible_layers(only_selected=False))
 
 
     def load_layers_sel(self):
@@ -466,8 +466,7 @@ class StitcherQWidget(QWidget):
             )
             return
 
-        selected_layers = [l for l in self.compatible_layers if l in self.viewer.layers.selection]
-        self.load_layers(selected_layers)
+        self.load_layers(self._get_compatible_layers(only_selected=True))
 
 
     def load_layers(self, layers):
@@ -594,13 +593,12 @@ class StitcherQWidget(QWidget):
         for l in self.viewer.layers:
             if l.name in self.layers_selection.choices:
                 l.events.disconnect(self.watch_layer_changes)
-
-    @property
-    def compatible_layers(self):
-        """
-        Check if layers are compatible with the current widget.
-        """
-        return [l for l in self.viewer.layers if isinstance(l, (Image, Labels))]
+    
+    def _get_compatible_layers(self, only_selected=False):
+        if only_selected:
+            return [l for l in self.viewer.layers.selection if isinstance(l, (Image, Labels))]
+        else:
+            return [l for l in self.viewer.layers if isinstance(l, (Image, Labels))]
 
 
 if __name__ == "__main__":

--- a/src/napari_stitcher/_tests/test_stitcher_widget.py
+++ b/src/napari_stitcher/_tests/test_stitcher_widget.py
@@ -241,3 +241,37 @@ def test_vanilla_layers_2D_no_time(make_napari_viewer):
     wdg.button_load_layers_all.clicked()
     wdg.run_registration()
     wdg.run_fusion()
+
+
+def test_load_layers_filters_non_image_layers(make_napari_viewer):
+    viewer = make_napari_viewer()
+
+    # Add image and non-image layers
+    viewer.add_image(np.random.random((10, 10)), name='image_layer')
+    viewer.add_points(np.random.random((10, 2)), name='points_layer')
+
+    wdg = StitcherQWidget(viewer)
+    viewer.window.add_dock_widget(wdg)
+
+    wdg.button_load_layers_all.clicked()
+
+    # Check if only image layer is loaded
+    assert len(wdg.input_layers) == 1
+    assert wdg.input_layers[0].name == 'image_layer'
+
+
+def test_fuse_register_buttons_not_grayed_out(make_napari_viewer):
+    viewer = make_napari_viewer()
+
+    # Add image and labels layers
+    viewer.add_image(np.random.random((10, 10)), name='image_layer')
+    viewer.add_labels(np.random.randint(0, 2, (10, 10)), name='labels_layer')
+
+    wdg = StitcherQWidget(viewer)
+    viewer.window.add_dock_widget(wdg)
+
+    wdg.button_load_layers_all.clicked()
+
+    # Check if the buttons are not grayed out
+    assert wdg.button_stitch.enabled
+    assert wdg.button_fuse.enabled


### PR DESCRIPTION
Fixes #5 

Minor change that checks whether a selected layer in the viewer for fusion is actually an image or a label. I used a convenience function to retrieve the layers of the correct kind which is then called in both the load all and load selected functions:

```python
    def _get_compatible_layers(self, only_selected=False):
        if only_selected:
            return [l for l in self.viewer.layers.selection if isinstance(l, (Image, Labels))]
        else:
            return [l for l in self.viewer.layers if isinstance(l, (Image, Labels))]
```

I also added some warnings in case an invalid selection is passed. Let me know what you think :)