### PR TITLE
Review dependencies in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,11 +31,17 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    numpy >=1.18
+    dask
     magicgui
+    multiscale_spatial_image
+    multiview-stitcher >=0.1.19
+    napari
+    numpy >=1.18
     qtpy
+    spatial_image
     tifffile >=2022.7.28
-    multiview-stitcher[aicsimageio] ==0.1.19
+    tqdm
+    xarray
 
 python_requires = >=3.10
 include_package_data = True
@@ -52,6 +58,7 @@ napari.manifest =
 [options.extras_require]
 testing_no_gui = # napari and pyqt5 can be installed via conda
     tox
+    multiview-stitcher[aicsimageio]
     pytest  # https://docs.pytest.org/en/latest/contents.html
     pytest-cov  # https://pytest-cov.readthedocs.io/en/latest/
     pytest-qt  # https://pytest-qt.readthedocs.io/en/latest/

--- a/src/napari_stitcher/viewer_utils.py
+++ b/src/napari_stitcher/viewer_utils.py
@@ -1,5 +1,4 @@
 import numpy as np
-import networkx as nx
 import xarray as xr
 import dask.array as da
 from dask import compute


### PR DESCRIPTION
This commit tries to list all direct dependencies explicitly.

This is what running `pixi x pipreqs .\src` produces:

```
dask==2025.3.0
magicgui==0.10.0
multiscale_spatial_image==2.0.2
multiview_stitcher==0.1.23
napari==0.5.6
networkx==3.4.2
numpy==2.2.4
pytest==8.3.5
qtpy==2.4.3
spatial_image==1.2.1
tifffile==2025.3.30
tqdm==4.67.1
xarray==2025.3.1
```

The `multiview-stitcher[aicsimageio]` dependency moves to the test dependencies, as it's only required to load test data.
