### PR TITLE
Remove aicsimageio from testing dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     dask
     magicgui
     multiscale_spatial_image
-    multiview-stitcher >=0.1.19
+    multiview-stitcher >=0.1.24
     napari
     numpy >=1.18
     qtpy
@@ -58,7 +58,7 @@ napari.manifest =
 [options.extras_require]
 testing_no_gui = # napari and pyqt5 can be installed via conda
     tox
-    multiview-stitcher[aicsimageio]
+    multiview-stitcher[czi] >=0.1.24
     pytest  # https://docs.pytest.org/en/latest/contents.html
     pytest-cov  # https://pytest-cov.readthedocs.io/en/latest/
     pytest-qt  # https://pytest-qt.readthedocs.io/en/latest/

--- a/src/napari_stitcher/_tests/test_mosaic_widget.py
+++ b/src/napari_stitcher/_tests/test_mosaic_widget.py
@@ -16,7 +16,7 @@ import pytest
         [3, 2, 2, 'snake by columns', 1],
     ]
 )
-def test_data_loading_while_plugin_open(
+def test_mosaic_loading(
     ndim, n_rows, n_cols, mosaic_arr, n_channels, make_napari_viewer
     ):
 

--- a/src/napari_stitcher/_tests/test_reader.py
+++ b/src/napari_stitcher/_tests/test_reader.py
@@ -5,19 +5,6 @@ from napari_stitcher import napari_get_reader, _reader
 from multiview_stitcher.sample_data import get_mosaic_sample_data_path
 
 
-def test_read_mosaic_image_into_list_of_spatial_xarrays():
-
-    test_path = get_mosaic_sample_data_path()
-    
-    view_sims = _reader.read_mosaic_image_into_list_of_spatial_xarrays(test_path)
-
-    assert 2 == len(view_sims)
-    assert min([ax in view_sims[0].dims for ax in ['x', 'y']])
-
-    return
-
-
-# tmp_path is a pytest fixture
 def test_reader():
     """An example of how you might test your plugin."""
 


### PR DESCRIPTION
`multiview-stitcher >= 0.1.24` does not require `acisimageio` anymore for loading test data.