### PR TITLE
Add binning for fusion

### DIFF
--- a/src/napari_stitcher/_stitcher_widget.py
+++ b/src/napari_stitcher/_stitcher_widget.py
@@ -381,6 +381,13 @@ class StitcherQWidget(QWidget):
                                             self.times_slider.value[1] + 1)]})
                     for sim in sims]
 
+            # check which keys are in spacing that are missing in fusion_binning and add them
+            if fusion_binning is not None:
+                spacing = spatial_image_utils.get_spacing_from_sim(sims[0])
+                for key in spacing.keys():
+                    if key not in fusion_binning:
+                        fusion_binning[key] = spacing[key]
+
             fused = fusion.fuse(
                 sims,
                 transform_key='affine_registered'

--- a/src/napari_stitcher/_stitcher_widget.py
+++ b/src/napari_stitcher/_stitcher_widget.py
@@ -77,7 +77,7 @@ class StitcherQWidget(QWidget):
             choices=[],
             tooltip='Choose a file to process using napari-stitcher.')
         
-        self.custom_reg_binning = widgets.CheckBox(value=False, text='Use custom registration binning')
+        self.custom_reg_binning = widgets.CheckBox(value=False, text='Use custom binning')
         self.x_reg_binning = widgets.Slider(value=1, min=1, max=10, label='X binning:')
         self.y_reg_binning = widgets.Slider(value=1, min=1, max=10, label='Y binning:')
 
@@ -363,6 +363,10 @@ class StitcherQWidget(QWidget):
         """
 
         channels = self.reg_ch_picker.choices
+        if self.custom_reg_binning.value:
+            fusion_binning = {'y': self.x_reg_binning.value, 'x': self.y_reg_binning.value}
+        else:
+            fusion_binning = None
 
         for _, ch in enumerate(channels):
 
@@ -382,6 +386,7 @@ class StitcherQWidget(QWidget):
                 transform_key='affine_registered'
                 if self.visualization_type_rbuttons.value == CHOICE_REGISTERED
                 else 'affine_metadata',
+                output_spacing=fusion_binning,
             )
 
             fused = fused.expand_dims({'c': [sims[0].coords['c'].values]})


### PR DESCRIPTION
Fixes #13 

Hi @m-albert ,

the changes to bring this feature into the plugin were actually quite minimal :) I took the liberty of renaming the binning option in the advanced settings tab so that they'd be valid for both registration and fusion. Otherwise, unlike the registration call, the `fuse` command required the target spacing in all axes, so I had to gather the `z-spacing` and paste it into the `output_spacing`.

Let me know what you think :)